### PR TITLE
Fix/cheerio and path bugs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,7 +39,7 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
     let urlData = [];
 
     allPagePaths.filter(path => options.excludePaths.indexOf(path) === -1).forEach(path => {
-        const filePath = path + (path.indexOf(".html") === -1 ? "index.html" : "");
+        const filePath = path + (path.indexOf(".html") === -1 ? "/index.html" : "");
 
         const fileContent = fs.readFileSync(`${options.buildDir}${filePath}`).toString("utf8");
         const pageDOM = cheerio.load(fileContent, {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,4 @@
-const cheerio = require("cheerio");
+const cheerio = require("cheerio").default;
 const sm = require("sitemap");
 const fs = require("fs");
 const defaultOptions = require('./default-options');


### PR DESCRIPTION
### Changes: 
- Adds default import of Cheerio function to resolve "Cheerio is not a function issue". As recommended here: 
-- https://github.com/wayfair/dociql/issues/36#issuecomment-843624810
- Prepends `/` to `index.html` in path generation so `fs` can find it. `index.html` is found in the path directory (which does not include a trailing `/`)